### PR TITLE
Allow to deactivate reboot_handler

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,3 +22,5 @@ default['windows']['allow_pending_reboots'] = true
 default['windows']['allow_reboot_on_failure'] = false
 default['windows']['rubyzipversion'] = nil
 default['windows']['reboot_timeout'] = 60
+
+default['windows']['reboot_handler_action'] = :enable

--- a/recipes/reboot_handler.rb
+++ b/recipes/reboot_handler.rb
@@ -28,5 +28,5 @@ chef_handler 'WindowsRebootHandler' do
   source "#{node['chef_handler']['handler_path']}/windows_reboot_handler.rb"
   arguments node['windows']['allow_pending_reboots']
   supports :report => true, :exception => node['windows']['allow_reboot_on_failure']
-  action :enable
+  action node['windows']['reboot_handler_action'].to_sym
 end


### PR DESCRIPTION
We still need to put the code on disk to allow to subclass it.
