### PR TITLE
Replace deprecated method win_friendly_path

### DIFF
--- a/resources/zipfile.rb
+++ b/resources/zipfile.rb
@@ -49,7 +49,7 @@ action :unzip do
                       new_resource.source
                     end
 
-  cache_file_path = win_friendly_path(cache_file_path)
+  cache_file_path = Chef::Util::PathHelper.cleanpath(cache_file_path)
 
   converge_by("unzip #{new_resource.source}") do
     ruby_block 'Unzipping' do


### PR DESCRIPTION
Update zipfile resource to replace deprecated method win_friendly_path by Chef::Util::PathHelper.cleanpath

### Description

Replace deprecated method win_friendly_path by Chef::Util::PathHelper.cleanpath

### Issues Resolved

Resolve no method error on win_friendly_path on more recent chef's version

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
